### PR TITLE
Change 'errors' folder location to root location

### DIFF
--- a/src/SimpleValidator/Validator.php
+++ b/src/SimpleValidator/Validator.php
@@ -63,8 +63,8 @@ class Validator {
     final protected function getDefaultErrorTexts($lang = null) {
         /* handle default error text file */
         $default_error_texts = array();
-        if (file_exists(__DIR__ . "/errors/" . $lang . ".php")) {
-            $default_error_texts = include(__DIR__ . "/errors/" . $lang . ".php");
+        if (file_exists("./errors/" . $lang . ".php")) {
+            $default_error_texts = include("./errors/" . $lang . ".php");
         }
         return $default_error_texts;
     }


### PR DESCRIPTION
I had  problems withs 'errors' folder. The **DIR** return the 
'src' folder, and the errors folder is a level above to the src folder. Any other solution?
